### PR TITLE
Signals and Related Functions

### DIFF
--- a/Scenes/Enemies/Ranger/enemy_ranger.gd
+++ b/Scenes/Enemies/Ranger/enemy_ranger.gd
@@ -37,6 +37,9 @@ var current_hp = base_max_hp
 @export var avoid_weight: float = 100
 @export var aggro_range: float = 900
 
+#signal variable for ranger shooting to be used by listeners
+signal ranger_shoot
+
 var state = MOVEMODE.AIMING
 var player:Player:
 	get:return Player.current
@@ -220,6 +223,8 @@ func shoot() -> void:
 	
 	# Play sound effect
 	# $AudioStreamPlayer.play()
+	#emit shoot signal for listeners
+	ranger_shoot.emit()
 
 func handle_waiting_state() -> void:
 	velocity = Vector2.ZERO

--- a/Scenes/PlayerCharacter/melee.gd
+++ b/Scenes/PlayerCharacter/melee.gd
@@ -3,6 +3,9 @@ class_name PlayerMelee
 
 @onready var t_MeleeCD:Timer = $MeleeCooldownTimer
 
+#signal variable for player melee to be used by listeners
+signal player_melee
+
 var player:Player:
 	get:return Player.current
 var attrs:Dictionary:
@@ -29,6 +32,8 @@ func try_melee() -> void:
 	$MelColl.debug_color.h = 0
 	
 	$AnimationPlayer.play("Melee_Anim")
+	#emit player_melee signal for listeners
+	player_melee.emit()
 	t_MeleeCD.start(MELEE_DELAY__S)
 	
 	for target:Node2D in get_overlapping_bodies():

--- a/Scenes/PlayerCharacter/player.gd
+++ b/Scenes/PlayerCharacter/player.gd
@@ -68,6 +68,10 @@ var collidingTileMaps:Array = []
 
 #signal variable for player footsteps called in Animation Player
 signal player_footstep
+#signal variable for player dodge start called in Animation Player
+signal player_dodge_start
+#signal variable for player dodge end called in Animation Player
+signal player_dodge_end
 		
 func _ready():
 	current = self
@@ -234,3 +238,13 @@ func _on_area_2d_body_exited(body: Node2D) -> void:
 #from the audio manager when specific frames of animation are played
 func call_player_footstep() -> void:
 	player_footstep.emit()
+
+#This function is triggered from the animation player to call for the dodge jump sound
+#from the audio manager when specific frames of animation are played	
+func call_player_dodge_start() -> void:
+	player_dodge_start.emit()
+
+#This function is triggered from the animation player to call for the dodge land sound
+#from the audio manager when specific frames of animation are played
+func call_player_dodge_end() -> void:
+	player_dodge_end.emit()

--- a/Scenes/PlayerCharacter/shooter.gd
+++ b/Scenes/PlayerCharacter/shooter.gd
@@ -3,6 +3,9 @@ class_name PlayerShooter
 
 @onready var t_Refire:Timer = $RefireTimer
 
+#signal variable for player shooting to be used by audio manager
+signal player_shoot
+
 const sc_bullet := preload("res://Animations/VFX/projectile_1.tscn")
 const REFIRE__S:float = 0.2 # base refire delay
 const BULLET_SPREAD:float = deg_to_rad(3)
@@ -30,7 +33,8 @@ func try_shoot() -> void:
 		return
 		
 	t_Refire.start(refire__s)
-	
+	#emit player shoot signal for listeners
+	player_shoot.emit()
 	
 	var count:int = attrs["bullet_count"]
 	var arc:float = deg_to_rad(attrs["bullet_arc"])


### PR DESCRIPTION
Added:

-ranger shoot signal and related call of that signal when the ranger shoots
-player melee signal and related call of that signal when the player uses melee
-player dodge start/end signals and related functions for when the player starts and ends a dodge
-player shoot signal and related call when the player shoots