### PR TITLE
Enemy and Item Balance

### DIFF
--- a/Scenes/Enemies/Bruiser/EnemyBruiser.gd
+++ b/Scenes/Enemies/Bruiser/EnemyBruiser.gd
@@ -20,13 +20,13 @@ enum MOVEMODE {
 
 @export_group("Health and Damage")
 ## Maximum total health base
-@export var base_max_hp: float = 24
+@export var base_max_hp: float = 32
 # current HP
 var current_hp = base_max_hp
 ## HP increase per level (ex. level 3 HP = 24 + (12 + 12))
 @export var max_hp_scaling: float = 12
 ## Attack damage per hit
-@export var damage: float = 16
+@export var damage: float = 20
 ## Wind up window before damage is applied after the enemy starts attacking in seconds
 @export var attack_buffer: float = 0.5
 

--- a/Scenes/Enemies/Ranger/EnemyRanger.gd
+++ b/Scenes/Enemies/Ranger/EnemyRanger.gd
@@ -35,7 +35,7 @@ var current_hp = base_max_hp
 
 @export_group("Movement")
 ## How fast this enemy normally moves
-@export var move_speed: float = 75
+@export var move_speed: float = 95
 @export var min_flee_range: float = 300
 @export var max_flee_range: float = 400
 ## How far an object can be before the enemy detects it in pixels

--- a/Scenes/Enemies/Swarm/EnemySwarm.gd
+++ b/Scenes/Enemies/Swarm/EnemySwarm.gd
@@ -15,11 +15,11 @@ enum MOVEMODE {
 
 @export_group("Health and Damage")
 ## Maximum total health base
-@export var base_max_hp: float = 24
+@export var base_max_hp: float = 10
 #
 var current_hp = base_max_hp
 ## HP increase per level (ex. level 3 HP = 24 + (12 + 12))
-@export var max_hp_scaling: float = 12
+@export var max_hp_scaling: float = 4
 ## Attack damage per hit
 @export var damage: float = 16
 @export var attack_radius: float = 50

--- a/Scenes/Pickups/base_pickup.gd
+++ b/Scenes/Pickups/base_pickup.gd
@@ -46,7 +46,7 @@ var pickups:Dictionary = {
 			"bullet_accuracy": "=1",
 			"bullet_piercing": "=1",
 			"bullet_count": "=1",
-			"melee_damage": "=5",
+			"melee_damage": "=10",
 			"dodge_speed": "=1",
 			"stamina": "=4"
 		}
@@ -62,7 +62,7 @@ var pickups:Dictionary = {
 			"bullet_accuracy": "=1.75",
 			"bullet_piercing": "=2",
 			"bullet_count": "=1",
-			"melee_damage": "=5",
+			"melee_damage": "=10",
 			"dodge_speed": "=1",
 			"stamina": "=4"
 		}
@@ -79,7 +79,7 @@ var pickups:Dictionary = {
 			"bullet_piercing": "=1",
 			"bullet_count": "=5",
 			"bullet_arc": "=30",
-			"melee_damage": "=5",
+			"melee_damage": "=10",
 			"dodge_speed": "=1",
 			"stamina": "=3"
 		}
@@ -92,13 +92,13 @@ var pickups:Dictionary = {
 			"bullet_speed": "=1",
 			"bullet_range": "=7",
 			"bullet_size": "=0.5",
-			"bullet_firing_rate": "=2.2",
-			"bullet_accuracy": "=0.5",
+			"bullet_firing_rate": "=2.1",
+			"bullet_accuracy": "=0.4",
 			"bullet_piercing": "=1",
 			"bullet_count": "=1",
-			"melee_damage": "=5",
+			"melee_damage": "=7",
 			"dodge_speed": "=1",
-			"stamina": "=5"
+			"stamina": "=4"
 		}
 	},
 	Pickup.slug_chip: {
@@ -112,7 +112,7 @@ var pickups:Dictionary = {
 			"bullet_accuracy": "=1",
 			"bullet_piercing": "=3",
 			"bullet_count": "=1",
-			"melee_damage": "=5",
+			"melee_damage": "=10",
 			"dodge_speed": "=1",
 			"stamina": "=3"
 		}
@@ -120,7 +120,7 @@ var pickups:Dictionary = {
 	Pickup.blade_chip: {
 		"texture": "res://Scenes/Pickups/Pickup_PNGS/Blade Icon.png",
 		"mods": {
-			"bullet_damage": "=2",
+			"bullet_damage": "=3",
 			"bullet_speed": "=1",
 			"bullet_range": "=5",
 			"bullet_size": "=1",
@@ -128,9 +128,9 @@ var pickups:Dictionary = {
 			"bullet_accuracy": "=1",
 			"bullet_piercing": "=1",
 			"bullet_count": "=1",
-			"melee_damage": "=10",
+			"melee_damage": "=18",
 			"dodge_speed": "=1.2",
-			"stamina": "=5"
+			"stamina": "=6"
 		}
 	},
 	Pickup.transformer: {
@@ -162,8 +162,8 @@ var pickups:Dictionary = {
 		"texture": "res://Scenes/Pickups/Pickup_PNGS/power diverter.png",
 		"mods": {
 			"melee_damage": "-1",
-			"bullet_speed": "+10%",
-			"bullet_damage": "+3"
+			"bullet_speed": "+25%",
+			"bullet_damage": "+2"
 		}
 	},
 	Pickup.voltage_regulator: {
@@ -176,9 +176,9 @@ var pickups:Dictionary = {
 	Pickup.malware: {
 		"texture": "res://Scenes/Pickups/Pickup_PNGS/malware.png",
 		"mods": {
-			"dodge_speed": "-20%",
-			"bullet_accuracy": "-10%",
-			"bullet_damage": "+3"
+			"dodge_speed": "-10%",
+			"bullet_accuracy": "-50%",
+			"bullet_damage": "+2"
 		}
 	},
 	Pickup.overclock: {


### PR DESCRIPTION
The bruiser has been given more health and damage. The ranger has been made faster for the purpose of fleeing close range. The swarm has been given less health. Melee damage has been raised across the board. Repeat chip fire rate and accuracy has been slightly lowered. Stamina has been set back to default for most chips. Blade chip has had a minor bullet damage buff, and significant melee damage buff. Also gained more stamina. Power diverter has been given a damage nerf, but bullet speed buff. Malware has been given a small dodge speed buff. It has also been given a large bullet damage and accuracy nerf due to being too good with the repeat chip.